### PR TITLE
fix(ui): meeting committee modal fixes

### DIFF
--- a/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-committee-modal/meeting-committee-modal.component.html
+++ b/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-committee-modal/meeting-committee-modal.component.html
@@ -108,18 +108,18 @@
                 }
                 @if (hasVotingEnabledCommittee()) {
                   <td>
-                    <span class="text-sm text-gray-600">{{ member.role.name || '-' }}</span>
+                    <span class="text-sm text-gray-600">{{ member.role?.name || '-' }}</span>
                   </td>
                   <td>
-                    @if (member.voting_status) {
+                    @if (member.voting_status?.status) {
                       <span
                         class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border"
                         [ngClass]="{
-                          'bg-green-100 text-green-800 border-green-200': member.voting_status.status === 'voting',
-                          'bg-gray-100 text-gray-800 border-gray-200': member.voting_status.status === 'non-voting',
-                          'bg-amber-100 text-amber-800 border-amber-200': member.voting_status.status === 'alternate',
+                          'bg-green-100 text-green-800 border-green-200': member.voting_status?.status === 'voting',
+                          'bg-gray-100 text-gray-800 border-gray-200': member.voting_status?.status === 'non-voting',
+                          'bg-amber-100 text-amber-800 border-amber-200': member.voting_status?.status === 'alternate',
                         }">
-                        {{ member.voting_status.status | titlecase }}
+                        {{ member.voting_status?.status | titlecase }}
                       </span>
                     } @else {
                       <span class="text-sm text-gray-400">-</span>

--- a/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-committee-modal/meeting-committee-modal.component.html
+++ b/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-committee-modal/meeting-committee-modal.component.html
@@ -17,7 +17,7 @@
         control="committees"
         [options]="committees()"
         optionLabel="name"
-        optionValue="id"
+        optionValue="uid"
         placeholder="Select one or more committees"
         [filter]="true"
         filterPlaceHolder="Search committees"
@@ -99,7 +99,7 @@
                   </div>
                 </td>
                 <td>
-                  <span class="text-sm text-gray-600">{{ member.organization || '-' }}</span>
+                  <span class="text-sm text-gray-600">{{ member.organization?.name || '-' }}</span>
                 </td>
                 @if (form.value.committees.length > 1) {
                   <td>
@@ -108,18 +108,18 @@
                 }
                 @if (hasVotingEnabledCommittee()) {
                   <td>
-                    <span class="text-sm text-gray-600">{{ member.role || '-' }}</span>
+                    <span class="text-sm text-gray-600">{{ member.role.name || '-' }}</span>
                   </td>
                   <td>
                     @if (member.voting_status) {
                       <span
                         class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border"
                         [ngClass]="{
-                          'bg-green-100 text-green-800 border-green-200': member.voting_status === 'voting',
-                          'bg-gray-100 text-gray-800 border-gray-200': member.voting_status === 'non-voting',
-                          'bg-amber-100 text-amber-800 border-amber-200': member.voting_status === 'alternate',
+                          'bg-green-100 text-green-800 border-green-200': member.voting_status.status === 'voting',
+                          'bg-gray-100 text-gray-800 border-gray-200': member.voting_status.status === 'non-voting',
+                          'bg-amber-100 text-amber-800 border-amber-200': member.voting_status.status === 'alternate',
                         }">
-                        {{ member.voting_status | titlecase }}
+                        {{ member.voting_status.status | titlecase }}
                       </span>
                     } @else {
                       <span class="text-sm text-gray-400">-</span>

--- a/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-committee-modal/meeting-committee-modal.component.ts
+++ b/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-committee-modal/meeting-committee-modal.component.ts
@@ -100,8 +100,8 @@ export class MeetingCommitteeModalComponent {
     });
 
     // Set initial selected committees
-    if (this.meeting.meeting_committees && this.meeting.meeting_committees.length > 0) {
-      const committeeIds = this.meeting.meeting_committees.map((c) => c.uid);
+    if (this.meeting.committees && this.meeting.committees.length > 0) {
+      const committeeIds = this.meeting.committees.map((c) => c.uid);
       this.selectedCommitteeIds.set(committeeIds);
       this.form.patchValue({ committees: committeeIds });
       // Load members for initially selected committees
@@ -126,7 +126,7 @@ export class MeetingCommitteeModalComponent {
     const selectedIds = this.form.value.committees as string[];
 
     // If no changes, just close
-    const currentIds = this.meeting.meeting_committees?.map((c) => c.uid) || [];
+    const currentIds = this.meeting.committees?.map((c) => c.uid) || [];
     if (JSON.stringify(selectedIds.sort()) === JSON.stringify(currentIds.sort())) {
       this.ref.close();
       return;


### PR DESCRIPTION
This pull request updates how committees and their members are handled in the meeting committee modal and related backend logic. The main changes improve data consistency by standardizing committee references, ensure correct display of nested member properties in the UI, and enhance the backend to provide both individual registrant and committee member counts for meetings.

**Frontend: Committee and Member Data Handling**
* Changed the value used for committee selection from `id` to `uid` in the modal, and updated all references to committees in the component logic to use the `committees` property instead of `meeting_committees` for consistency. [[1]](diffhunk://#diff-238b1b9cf4917f882f79ce7922c749e13b280c209aa6a6452ddb9266a17a5897L20-R20) [[2]](diffhunk://#diff-00edff3cbdc20548678ac5d76a17bf11f5e3bb382922d1dce5d86c26a0510525L103-R104) [[3]](diffhunk://#diff-00edff3cbdc20548678ac5d76a17bf11f5e3bb382922d1dce5d86c26a0510525L129-R129)
* Updated the display logic for committee member information to correctly access nested properties: organization name, role name, and voting status are now displayed from their respective nested objects. [[1]](diffhunk://#diff-238b1b9cf4917f882f79ce7922c749e13b280c209aa6a6452ddb9266a17a5897L102-R102) [[2]](diffhunk://#diff-238b1b9cf4917f882f79ce7922c749e13b280c209aa6a6452ddb9266a17a5897L111-R122)

**Backend: Meeting Data Aggregation**
* Enhanced the `MeetingController` to aggregate and return both the count of individual registrants and the total number of committee members for each meeting by fetching committee members using the `CommitteeService`. [[1]](diffhunk://#diff-bbb1241ff93bb4fd4cfba77f757ba86d5b9325197284e6302b22cf88676d9186R16-R24) [[2]](diffhunk://#diff-bbb1241ff93bb4fd4cfba77f757ba86d5b9325197284e6302b22cf88676d9186L40-R62)