### PR TITLE
feat(api): add past-meetings endpoints and frontend integration

### DIFF
--- a/apps/lfx-pcc/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-pcc/src/app/shared/services/meeting.service.ts
@@ -38,6 +38,15 @@ export class MeetingService {
     );
   }
 
+  public getPastMeetings(params?: HttpParams): Observable<Meeting[]> {
+    return this.http.get<Meeting[]>('/api/past-meetings', { params }).pipe(
+      catchError((error) => {
+        console.error('Failed to load past meetings:', error);
+        return of([]);
+      })
+    );
+  }
+
   public getMeetingsByProject(projectId: string, limit?: number, orderBy?: string): Observable<Meeting[]> {
     let params = new HttpParams().set('tags', `project_uid:${projectId}`);
 
@@ -70,18 +79,27 @@ export class MeetingService {
   public getPastMeetingsByProject(projectId: string, limit: number = 3): Observable<Meeting[]> {
     let params = new HttpParams().set('tags', `project_uid:${projectId}`);
 
-    // TODO: Add filter for past meetings
     if (limit) {
       params = params.set('limit', limit.toString());
     }
 
-    return this.getMeetings(params);
+    return this.getPastMeetings(params);
   }
 
   public getMeeting(id: string): Observable<Meeting> {
     return this.http.get<Meeting>(`/api/meetings/${id}`).pipe(
       catchError((error) => {
         console.error(`Failed to load meeting ${id}:`, error);
+        return throwError(() => error);
+      }),
+      tap((meeting) => this.meeting.set(meeting))
+    );
+  }
+
+  public getPastMeeting(id: string): Observable<Meeting> {
+    return this.http.get<Meeting>(`/api/past-meetings/${id}`).pipe(
+      catchError((error) => {
+        console.error(`Failed to load past meeting ${id}:`, error);
         return throwError(() => error);
       }),
       tap((meeting) => this.meeting.set(meeting))

--- a/apps/lfx-pcc/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-pcc/src/server/controllers/past-meeting.controller.ts
@@ -1,0 +1,117 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import { Logger } from '../helpers/logger';
+import { validateUidParameter } from '../helpers/validation.helper';
+import { MeetingService } from '../services/meeting.service';
+
+/**
+ * Controller for handling past meeting HTTP requests
+ */
+export class PastMeetingController {
+  private meetingService: MeetingService = new MeetingService();
+
+  /**
+   * GET /past-meetings
+   */
+  public async getPastMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = Logger.start(req, 'get_past_meetings', {
+      query_params: Logger.sanitize(req.query as Record<string, any>),
+    });
+
+    try {
+      // Get the past meetings using meetingType 'past_meeting'
+      const meetings = await this.meetingService.getMeetings(req, req.query as Record<string, any>, 'past_meeting');
+
+      // TODO: Remove this once we have a way to get the registrants count
+      const counts = await Promise.all(
+        meetings.map(async (m) => {
+          const registrants = await this.meetingService.getMeetingRegistrants(req, m.uid);
+          const committeeMembers = registrants.filter((r) => r.type === 'committee').length ?? 0;
+
+          return {
+            individual_registrants_count: registrants.length - committeeMembers,
+            committee_members_count: committeeMembers,
+          };
+        })
+      );
+
+      meetings.forEach((m, i) => {
+        m.individual_registrants_count = counts[i].individual_registrants_count;
+        m.committee_members_count = counts[i].committee_members_count;
+      });
+
+      // Log the success
+      Logger.success(req, 'get_past_meetings', startTime, {
+        meeting_count: meetings.length,
+      });
+
+      // Send the meetings data to the client
+      res.json(meetings);
+    } catch (error) {
+      // Log the error
+      Logger.error(req, 'get_past_meetings', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /past-meetings/:uid
+   */
+  public async getPastMeetingById(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid } = req.params;
+    const startTime = Logger.start(req, 'get_past_meeting_by_id', {
+      meeting_uid: uid,
+    });
+
+    try {
+      // Check if the meeting UID is provided
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'get_past_meeting_by_id',
+          service: 'past_meeting_controller',
+          logStartTime: startTime,
+        })
+      ) {
+        return;
+      }
+
+      // Get the past meeting by ID using meetingType 'past_meeting'
+      const meeting = await this.meetingService.getMeetingById(req, uid, 'past_meeting');
+
+      // Log the success
+      Logger.success(req, 'get_past_meeting_by_id', startTime, {
+        meeting_uid: uid,
+        project_uid: meeting.project_uid,
+        title: meeting.title,
+      });
+
+      // TODO: Remove this once we have a way to get the registrants count
+      try {
+        const registrants = await this.meetingService.getMeetingRegistrants(req, meeting.uid);
+        const committeeMembers = registrants.filter((r) => r.type === 'committee').length ?? 0;
+
+        meeting.individual_registrants_count = registrants.length - committeeMembers;
+        meeting.committee_members_count = committeeMembers;
+      } catch (error) {
+        // Log the error
+        Logger.error(req, 'get_past_meeting_by_id', startTime, error, {
+          meeting_uid: uid,
+        });
+      }
+
+      // Send the meeting data to the client
+      res.json(meeting);
+    } catch (error) {
+      // Log the error
+      Logger.error(req, 'get_past_meeting_by_id', startTime, error, {
+        meeting_uid: uid,
+      });
+
+      // Send the error to the next middleware
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-pcc/src/server/routes/past-meetings.route.ts
+++ b/apps/lfx-pcc/src/server/routes/past-meetings.route.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import express from 'express';
+
+import { PastMeetingController } from '../controllers/past-meeting.controller';
+
+const router = express.Router();
+const pastMeetingController = new PastMeetingController();
+
+// Past meeting routes
+router.get('/', (req, res, next) => pastMeetingController.getPastMeetings(req, res, next));
+
+// Get past meeting by UID
+router.get('/:uid', (req, res, next) => pastMeetingController.getPastMeetingById(req, res, next));
+
+export default router;

--- a/apps/lfx-pcc/src/server/server.ts
+++ b/apps/lfx-pcc/src/server/server.ts
@@ -20,6 +20,7 @@ import { apiErrorHandler } from './middleware/error-handler.middleware';
 import { protectedRoutesMiddleware } from './middleware/protected-routes.middleware';
 import committeesRouter from './routes/committees.route';
 import meetingsRouter from './routes/meetings.route';
+import pastMeetingsRouter from './routes/past-meetings.route';
 import permissionsRouter from './routes/permissions.route';
 import projectsRouter from './routes/projects.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
@@ -202,6 +203,7 @@ app.use('/api/projects', projectsRouter);
 app.use('/api/projects', permissionsRouter);
 app.use('/api/committees', committeesRouter);
 app.use('/api/meetings', meetingsRouter);
+app.use('/api/past-meetings', pastMeetingsRouter);
 
 // Add API error handler middleware
 app.use('/api/*', apiErrorHandler);

--- a/apps/lfx-pcc/src/server/services/meeting.service.ts
+++ b/apps/lfx-pcc/src/server/services/meeting.service.ts
@@ -38,10 +38,10 @@ export class MeetingService {
   /**
    * Fetches all meetings based on query parameters
    */
-  public async getMeetings(req: Request, query: Record<string, any> = {}): Promise<Meeting[]> {
+  public async getMeetings(req: Request, query: Record<string, any> = {}, meetingType: string = 'meeting'): Promise<Meeting[]> {
     const params = {
       ...query,
-      type: 'meeting',
+      type: meetingType,
     };
 
     const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Meeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', params);
@@ -61,9 +61,9 @@ export class MeetingService {
   /**
    * Fetches a single meeting by UID
    */
-  public async getMeetingById(req: Request, meetingUid: string): Promise<Meeting> {
+  public async getMeetingById(req: Request, meetingUid: string, meetingType: string = 'meeting'): Promise<Meeting> {
     const params = {
-      type: 'meeting',
+      type: meetingType,
       tags: `meeting_uid:${meetingUid}`,
     };
 


### PR DESCRIPTION
## Summary

This PR implements new API endpoints for retrieving past meetings and updates the frontend service to properly filter past meetings by project, addressing the TODO comment in `getPastMeetingsByProject()`.

## Changes Made

### Backend Implementation
- **Updated MeetingService** to accept `meetingType` parameter in `getMeetings()` and `getMeetingById()` methods
- **Created PastMeetingController** that handles past meeting requests using 'past_meeting' type  
- **Created past-meetings routes** with two endpoints:
  - `GET /api/past-meetings` - Lists all past meetings
  - `GET /api/past-meetings/:uid` - Gets specific past meeting by UID
- **Registered routes** in server.ts at `/api/past-meetings`

### Frontend Implementation  
- **Added `getPastMeetings()`** method for general past meeting queries
- **Updated `getPastMeetingsByProject()`** to use new past-meetings endpoint (removed TODO)
- **Added `getPastMeeting()`** method for individual past meeting retrieval

## Technical Details
- Reuses existing MeetingService logic by parameterizing meeting type
- Maintains consistent API structure and error handling  
- No code duplication - clean separation of concerns
- All endpoints include registrant counting logic

## Test Plan

- [x] Code passes linting
- [x] Build succeeds without errors  
- [x] Pre-commit hooks pass
- [x] All formatting applied

## Breaking Changes

None - this is a purely additive change.

## Linked Issues

Resolves LFXV2-450

---

Generated with [Claude Code](https://claude.ai/code)