### PR TITLE
feat(helm): template support for external secrets

### DIFF
--- a/charts/lfx-v2-ui/Chart.yaml
+++ b/charts/lfx-v2-ui/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-v2-ui
 description: A Helm chart for LFX v2 UI - Angular SSR application with Express backend
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "latest"
 keywords:
   - lfx

--- a/charts/lfx-v2-ui/Chart.yaml
+++ b/charts/lfx-v2-ui/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-v2-ui
 description: A Helm chart for LFX v2 UI - Angular SSR application with Express backend
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "latest"
 keywords:
   - lfx

--- a/charts/lfx-v2-ui/README.md
+++ b/charts/lfx-v2-ui/README.md
@@ -265,9 +265,10 @@ This chart supports the [External Secrets Operator](https://external-secrets.io/
 | `externalSecrets.enabled`                 | Enable External Secrets integration              | `false`        |
 | `externalSecrets.provider`                | Provider configuration (required when enabled)   | `{}`           |
 | `externalSecrets.name`                    | Name of the ExternalSecret resource              | Auto-generated |
-| `externalSecrets.target`                  | Target Kubernetes Secret name (required)         | `""`           |
+| `externalSecrets.target.name`             | Target Kubernetes Secret name (required)         | `""`           |
+| `externalSecrets.target.template`         | Template for generating the secret content       | `{}`           |
+| `externalSecrets.target.creationPolicy`   | Secret creation policy (Owner/Orphan/Merge/None) | `Owner`        |
 | `externalSecrets.refreshInterval`         | How often to sync secrets from provider          | `10m`          |
-| `externalSecrets.creationPolicy`          | Secret creation policy (Owner/Orphan/Merge/None) | `Owner`        |
 | `externalSecrets.dataFrom`                | Fetch multiple secrets using queries (required)  | `[]`           |
 | `externalSecrets.annotations`             | Annotations for ExternalSecret resource          | `{}`           |
 | `externalSecrets.secretStore.name`        | Name of the SecretStore resource                 | Auto-generated |
@@ -288,6 +289,8 @@ externalSecrets:
         jwt:
           serviceAccountRef:
             name: lfx-v2-ui-sa # ServiceAccount with IRSA annotation
+  target:
+    name: lfx-v2-ui
   dataFrom:
     - find:
         tags:

--- a/charts/lfx-v2-ui/templates/externalsecret.yaml
+++ b/charts/lfx-v2-ui/templates/externalsecret.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 {{- if .Values.externalSecrets.enabled }}
 {{- $dataFrom := .Values.externalSecrets.dataFrom | required "externalSecrets.dataFrom is required." }}
-{{- $target := .Values.externalSecrets.target | required "externalSecrets.target is required." }}
+{{- $targetName := .Values.externalSecrets.target.name | required "externalSecrets.target.name is required." }}
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -21,8 +21,12 @@ spec:
     name: {{ include "lfx-v2-ui.secretStoreName" . }}
     kind: SecretStore
   target:
-    name: {{ $target }}
-    creationPolicy: {{ .Values.externalSecrets.creationPolicy }}
+    name: {{ $targetName }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy }}
+    {{- if .Values.externalSecrets.target.template }}
+    template:
+      {{- toYaml .Values.externalSecrets.target.template | nindent 6 }}
+    {{- end }}
   dataFrom:
     {{- toYaml $dataFrom | nindent 4 }}
 {{- end }}

--- a/charts/lfx-v2-ui/values.yaml
+++ b/charts/lfx-v2-ui/values.yaml
@@ -51,20 +51,35 @@ externalSecrets:
   # Defaults to the fullname template if not specified
   name: ""
 
-  # Target Kubernetes Secret name (required)
-  # This is the name of the Secret that will be created/managed
-  target: ""
-
   # How frequently the secret should be refreshed from the external provider
   # Format: 10s, 1m, 1h, etc. (default: 10m)
   refreshInterval: "10m"
 
-  # Creation policy for the target Secret
-  # - Owner: ExternalSecret owns the Secret, deletion of ExternalSecret deletes the Secret
-  # - Orphan: Secret won't be deleted when ExternalSecret is deleted
-  # - Merge: Merge with existing Secret if it exists
-  # - None: Don't create or update the Secret
-  creationPolicy: "Owner"
+  # Target Kubernetes Secret configuration
+  target:
+    # Name of the Secret that will be created/managed (required)
+    # This is the name of the Secret that will be created/managed
+    name: ""
+
+    # Creation policy for the target Secret
+    # - Owner: ExternalSecret owns the Secret, deletion of ExternalSecret deletes the Secret
+    # - Orphan: Secret won't be deleted when ExternalSecret is deleted
+    # - Merge: Merge with existing Secret if it exists
+    # - None: Don't create or update the Secret
+    creationPolicy: "Owner"
+
+    # Template for generating the Secret content
+    # Allows transformation of secret data before creating the Kubernetes Secret
+    # Example:
+    #   template:
+    #     engineVersion: v2
+    #     data:
+    #       config.json: |
+    #         {
+    #           "apiKey": "{{ .apiKey }}",
+    #           "secretKey": "{{ .secretKey }}"
+    #         }
+    template: {}
 
   # Fetch multiple secrets using queries (required)
   # Example:

--- a/charts/lfx-v2-ui/values.yaml
+++ b/charts/lfx-v2-ui/values.yaml
@@ -58,7 +58,6 @@ externalSecrets:
   # Target Kubernetes Secret configuration
   target:
     # Name of the Secret that will be created/managed (required)
-    # This is the name of the Secret that will be created/managed
     name: ""
 
     # Creation policy for the target Secret


### PR DESCRIPTION
  - restructure external secrets target configuration into nested object
  - add target.template field for secret data transformation
  - move creationPolicy under target configuration
  - move 'target' to 'target.name'
  - update documentation with new target structure and template examples
  - bump chart version from 0.2.0 to 0.2.1

This change enables more flexible secret generation by allowing
transformation of external secret data before creating kubernetes secrets

Issue: LFXV2-513

Generated with [Claude Code](https://claude.ai/code)
Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
