### PR TITLE
fix(meetings): use occurrence data for join page timing and display

### DIFF
--- a/apps/lfx-one/src/app/modules/meeting/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meeting/meeting-join/meeting-join.component.html
@@ -51,22 +51,22 @@
           <div class="flex sm:flex-row flex-col items-start justify-between mb-4" data-testid="meeting-title-section">
             <div class="flex-1 pr-4 flex-grow">
               <h2 class="text-xl font-display font-semibold text-gray-900 mb-1 leading-tight" data-testid="meeting-title">
-                {{ meeting().title }}
+                {{ currentOccurrence()?.title || meeting().title }}
               </h2>
             </div>
-            @if (meeting().start_time) {
+            @if (currentOccurrence()?.start_time || meeting().start_time; as startTime) {
               <div class="flex items-center gap-1 text-xs text-gray-600 bg-gray-100 px-2 py-1 rounded flex-shrink-0" data-testid="meeting-datetime">
                 <i class="fa-light fa-calendar-days text-gray-400"></i>
                 <span
-                  >{{ meeting()!.start_time | meetingTime: meeting()!.duration : 'date' }} •
-                  {{ meeting()!.start_time | meetingTime: meeting()!.duration : 'time' }}</span
+                  >{{ startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'date' }} •
+                  {{ startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'time' }}</span
                 >
               </div>
             }
           </div>
 
           <!-- Meeting Agenda -->
-          @if (meeting().description) {
+          @if (currentOccurrence()?.description || meeting().description; as description) {
             <div class="mb-4" data-testid="meeting-description">
               <div class="flex items-center gap-2 mb-2">
                 <i class="fa-light fa-file-lines text-gray-400"></i>
@@ -74,7 +74,7 @@
               </div>
               <lfx-expandable-text [maxHeight]="85">
                 <div class="text-sm text-gray-600 leading-relaxed bg-gray-50 rounded-lg p-3">
-                  <div [innerHTML]="meeting()!.description | linkify"></div>
+                  <div [innerHTML]="description | linkify"></div>
                 </div>
               </lfx-expandable-text>
             </div>
@@ -134,7 +134,7 @@
                 <i class="fa-light fa-clock text-gray-400"></i>
                 <span>Duration</span>
               </div>
-              <div class="text-sm font-sans">{{ meeting().duration }} minutes</div>
+              <div class="text-sm font-sans">{{ currentOccurrence()?.duration || meeting().duration }} minutes</div>
             </div>
           </div>
 

--- a/apps/lfx-one/src/app/modules/meeting/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meeting/meeting-join/meeting-join.component.ts
@@ -158,7 +158,7 @@ export class MeetingJoinComponent {
       const joinableOccurrence = meeting.occurrences.find((occurrence) => {
         const startTime = new Date(occurrence.start_time);
         const earliestJoinTime = new Date(startTime.getTime() - earlyJoinMinutes * 60000);
-        const latestJoinTime = new Date(startTime.getTime() + occurrence.duration * 60000); // 40 minutes after end
+        const latestJoinTime = new Date(startTime.getTime() + occurrence.duration * 60000 + 40 * 60000); // 40 minutes after end
 
         return now >= earliestJoinTime && now <= latestJoinTime;
       });
@@ -259,7 +259,7 @@ export class MeetingJoinComponent {
         const startTime = new Date(currentOccurrence.start_time);
         const earlyJoinMinutes = meeting.early_join_time_minutes || 10;
         const earliestJoinTime = new Date(startTime.getTime() - earlyJoinMinutes * 60000);
-        const latestJoinTime = new Date(startTime.getTime() + currentOccurrence.duration * 60000); // 40 minutes after end
+        const latestJoinTime = new Date(startTime.getTime() + currentOccurrence.duration * 60000 + 40 * 60000); // 40 minutes after end
 
         return now >= earliestJoinTime && now <= latestJoinTime;
       }
@@ -273,7 +273,7 @@ export class MeetingJoinComponent {
       const startTime = new Date(meeting.start_time);
       const earlyJoinMinutes = meeting.early_join_time_minutes || 10; // Default to 10 minutes
       const earliestJoinTime = new Date(startTime.getTime() - earlyJoinMinutes * 60000);
-      const latestJoinTime = new Date(startTime.getTime() + meeting.duration * 60000); // 40 minutes after end
+      const latestJoinTime = new Date(startTime.getTime() + meeting.duration * 60000 + 40 * 60000); // 40 minutes after end
 
       return now >= earliestJoinTime && now <= latestJoinTime;
     });


### PR DESCRIPTION
## Summary
Updates the meeting join page to use occurrence-specific data when available, ensuring correct timing and display information for recurring meetings.

## Test plan
- [x] Build passes successfully
- [x] Lint checks pass
- [x] Code formatted correctly
- [ ] Manual testing with meetings that have occurrences
- [ ] Verify fallback behavior for meetings without occurrences
- [ ] Test join timing calculations with 40-minute buffer

## Changes
- Added `currentOccurrence` computed signal to find the nearest future occurrence
- Updated `canJoinMeeting` logic to use occurrence-based timing with 40-minute buffer after meeting end
- Modified template to display occurrence-specific title, description, start time, and duration
- Enhanced `importantLinks` to use occurrence description when available
- Maintained backward compatibility with fallback to meeting data when no occurrences exist

## Impact
- Fixes incorrect meeting information display for recurring meetings
- Improves join timing accuracy for occurrence-based meetings
- Extends joinability window to 40 minutes after meeting end
- No breaking changes to existing functionality

Fixes LFXV2-525

🤖 Generated with [Claude Code](https://claude.ai/code)