### PR TITLE
fix(meetings): fix PDF file upload selection in meeting attachments

### DIFF
--- a/apps/lfx-one/src/app/modules/project/meetings/components/meeting-resources-summary/meeting-resources-summary.component.html
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/meeting-resources-summary/meeting-resources-summary.component.html
@@ -15,7 +15,7 @@
 
       <lfx-file-upload
         [multiple]="true"
-        accept="pdf,doc,docx,ppt,pptx,xls,xlsx,txt,md,image/*"
+        [accept]="acceptString"
         [maxFileSize]="10485760"
         (onSelect)="onFileSelect($event)"
         [customUpload]="true"

--- a/apps/lfx-one/src/app/modules/project/meetings/components/meeting-resources-summary/meeting-resources-summary.component.ts
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/meeting-resources-summary/meeting-resources-summary.component.ts
@@ -9,7 +9,7 @@ import { FileUploadComponent } from '@components/file-upload/file-upload.compone
 import { ALLOWED_FILE_TYPES, MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from '@lfx-one/shared/constants';
 import { RecurrenceType } from '@lfx-one/shared/enums';
 import { CustomRecurrencePattern, MeetingAttachment, PendingAttachment } from '@lfx-one/shared/interfaces';
-import { buildRecurrenceSummary } from '@lfx-one/shared/utils';
+import { buildRecurrenceSummary, generateAcceptString } from '@lfx-one/shared/utils';
 import { FileSizePipe } from '@pipes/file-size.pipe';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -51,6 +51,9 @@ export class MeetingResourcesSummaryComponent implements OnInit {
   // Navigation
   public readonly goToStep = output<number>();
   public readonly deleteAttachment = output<string>();
+
+  // File upload configuration
+  public readonly acceptString = generateAcceptString();
 
   public constructor() {}
 

--- a/apps/lfx-one/src/app/shared/components/file-upload/file-upload.component.ts
+++ b/apps/lfx-one/src/app/shared/components/file-upload/file-upload.component.ts
@@ -3,6 +3,7 @@
 
 import { CommonModule } from '@angular/common';
 import { Component, ContentChild, input, output, TemplateRef } from '@angular/core';
+import { getAcceptedFileTypesDisplay } from '@lfx-one/shared/utils';
 import { FileUploadModule } from 'primeng/fileupload';
 
 @Component({
@@ -75,6 +76,13 @@ export class FileUploadComponent {
     const accept = this.accept();
     if (!accept) return '';
 
+    // Check if accept string contains MIME types (our standard format)
+    if (accept.includes('application/') || accept.includes('image/') || accept.includes('text/')) {
+      // Use the presentable display function
+      return getAcceptedFileTypesDisplay();
+    }
+
+    // Fallback for custom accept strings
     const extensions = accept.split(',').map((ext) => ext.trim().replace(/\./g, '').toUpperCase());
     return extensions.join(', ');
   }

--- a/apps/lfx-one/src/app/shared/components/file-upload/file-upload.component.ts
+++ b/apps/lfx-one/src/app/shared/components/file-upload/file-upload.component.ts
@@ -76,13 +76,15 @@ export class FileUploadComponent {
     const accept = this.accept();
     if (!accept) return '';
 
-    // Check if accept string contains MIME types (our standard format)
-    if (accept.includes('application/') || accept.includes('image/') || accept.includes('text/')) {
-      // Use the presentable display function
+    // Check if accept string contains MIME types using regex pattern (type/subtype)
+    // This matches any valid MIME type format like image/*, application/pdf, audio/mp3, video/mp4, etc.
+    const mimeTypePattern = /\w+\/[\w+\-.*]+/;
+    if (mimeTypePattern.test(accept)) {
+      // Use the presentable display function for our standard format
       return getAcceptedFileTypesDisplay();
     }
 
-    // Fallback for custom accept strings
+    // Fallback for custom accept strings (extension-only format)
     const extensions = accept.split(',').map((ext) => ext.trim().replace(/\./g, '').toUpperCase());
     return extensions.join(', ');
   }

--- a/packages/shared/src/utils/file.utils.ts
+++ b/packages/shared/src/utils/file.utils.ts
@@ -1,6 +1,114 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { ALLOWED_FILE_TYPES } from '../constants/file-upload.constants';
+
+/**
+ * Map of MIME types to file extensions
+ */
+const MIME_TO_EXTENSIONS: Record<string, string[]> = {
+  'image/jpeg': ['.jpeg', '.jpg'],
+  'image/jpg': ['.jpg'],
+  'image/png': ['.png'],
+  'image/gif': ['.gif'],
+  'image/webp': ['.webp'],
+  'application/pdf': ['.pdf'],
+  'application/msword': ['.doc'],
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
+  'application/vnd.ms-excel': ['.xls'],
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+  'application/vnd.ms-powerpoint': ['.ppt'],
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': ['.pptx'],
+  'text/plain': ['.txt'],
+  'text/markdown': ['.md', '.markdown'],
+};
+
+/**
+ * Generate HTML accept attribute string from allowed MIME types
+ * Converts MIME types to both MIME and extension formats for better browser compatibility
+ * @returns Comma-separated string of accepted file types
+ * @example
+ * // Returns: ".pdf,.doc,.docx,...,application/pdf,application/msword,..."
+ * const acceptString = generateAcceptString();
+ */
+export function generateAcceptString(): string {
+  const acceptParts: string[] = [];
+  const addedExtensions = new Set<string>();
+
+  // Add both extensions and MIME types for maximum compatibility
+  ALLOWED_FILE_TYPES.forEach((mimeType) => {
+    // Add MIME type
+    acceptParts.push(mimeType);
+
+    // Add corresponding file extensions
+    const extensions = MIME_TO_EXTENSIONS[mimeType];
+    if (extensions) {
+      extensions.forEach((ext) => {
+        if (!addedExtensions.has(ext)) {
+          acceptParts.push(ext);
+          addedExtensions.add(ext);
+        }
+      });
+    }
+  });
+
+  return acceptParts.join(',');
+}
+
+/**
+ * Generate user-friendly display string of accepted file types
+ * @returns Human-readable string of accepted file types
+ * @example
+ * // Returns: "PDF, Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX), Images (JPG, PNG, GIF, WebP), Text (TXT, MD)"
+ * const displayString = getAcceptedFileTypesDisplay();
+ */
+export function getAcceptedFileTypesDisplay(): string {
+  const fileTypeGroups: { [key: string]: string[] } = {
+    PDF: [],
+    Word: [],
+    Excel: [],
+    PowerPoint: [],
+    Images: [],
+    Text: [],
+  };
+
+  ALLOWED_FILE_TYPES.forEach((mimeType) => {
+    const extensions = MIME_TO_EXTENSIONS[mimeType];
+    if (!extensions) return;
+
+    const displayExtensions = extensions.map((ext) => ext.substring(1).toUpperCase());
+
+    if (mimeType.includes('pdf')) {
+      fileTypeGroups['PDF'].push(...displayExtensions);
+    } else if (mimeType.includes('word')) {
+      fileTypeGroups['Word'].push(...displayExtensions);
+    } else if (mimeType.includes('excel') || mimeType.includes('spreadsheet')) {
+      fileTypeGroups['Excel'].push(...displayExtensions);
+    } else if (mimeType.includes('powerpoint') || mimeType.includes('presentation')) {
+      fileTypeGroups['PowerPoint'].push(...displayExtensions);
+    } else if (mimeType.startsWith('image/')) {
+      fileTypeGroups['Images'].push(...displayExtensions);
+    } else if (mimeType.startsWith('text/')) {
+      fileTypeGroups['Text'].push(...displayExtensions);
+    }
+  });
+
+  const displayParts: string[] = [];
+  Object.entries(fileTypeGroups).forEach(([groupName, extensions]) => {
+    if (extensions.length > 0) {
+      // Remove duplicates
+      const uniqueExtensions = [...new Set(extensions)];
+      if (groupName === 'PDF') {
+        displayParts.push('PDF');
+      } else {
+        displayParts.push(`${groupName} (${uniqueExtensions.join(', ')})`);
+      }
+    }
+  });
+
+  return displayParts.join(', ');
+}
+
 /**
  * Comprehensive filename sanitization to prevent security issues
  * and ensure cross-platform compatibility


### PR DESCRIPTION
## Summary
- Fixed PDF files not being selectable in the meeting file upload dialog
- Created utility functions to generate proper HTML accept attributes from MIME types
- Enhanced file type display to be more user-friendly

## JIRA Ticket
[LFXV2-599](https://linuxfoundation.atlassian.net/browse/LFXV2-599)

## Problem
PDF files could not be selected in the file picker dialog when uploading meeting attachments, despite PDFs being configured as allowed file types in the backend. This was caused by incorrect accept attribute syntax (`"pdf"` instead of `".pdf"` or `"application/pdf"`).

## Solution
1. Added `generateAcceptString()` utility function to convert MIME types to proper HTML accept format
2. Added `getAcceptedFileTypesDisplay()` for user-friendly file type presentation 
3. Updated meeting-resources-summary component to use dynamically generated accept string
4. Enhanced file-upload component to display presentable file types

## Files Changed
- `/packages/shared/src/utils/file.utils.ts` - Added utility functions
- `/apps/lfx-one/src/app/modules/project/meetings/components/meeting-resources-summary/meeting-resources-summary.component.ts` - Import and use utilities
- `/apps/lfx-one/src/app/modules/project/meetings/components/meeting-resources-summary/meeting-resources-summary.component.html` - Use dynamic accept string  
- `/apps/lfx-one/src/app/shared/components/file-upload/file-upload.component.ts` - Enhanced file type display

## Test Plan
- [ ] Verify PDF files are now selectable in the file picker dialog
- [ ] Confirm other file types (Word, Excel, PowerPoint, Images) are still selectable
- [ ] Check that the file type hint displays properly formatted text (e.g., "PDF, Word (DOC, DOCX), Excel (XLS, XLSX)...")
- [ ] Test uploading a PDF file to ensure it uploads successfully
- [ ] Verify file validation still works (size limits, file type restrictions)

[LFXV2-599]: https://linuxfoundation.atlassian.net/browse/LFXV2-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ