### PR TITLE
feat(search): implement user search for meeting registrants

### DIFF
--- a/apps/lfx-one/src/app/modules/project/meetings/components/meeting-registrants/meeting-registrants.component.html
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/meeting-registrants/meeting-registrants.component.html
@@ -139,7 +139,7 @@
           size="small"
           [form]="searchForm"
           control="search"
-          placeholder="Search guests..."
+          placeholder="Search invited guests..."
           icon="fa-light fa-search"
           styleClass="w-full"
           dataTest="search-input">

--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.html
@@ -24,7 +24,7 @@
             inputStyleClass="text-sm w-full"
             panelStyleClass="text-sm w-full"
             dataTestId="registrant-form-user-search"
-            (onUserSelect)="handleUserSelection($event)"
+            (onUserSelect)="handleUserSelection()"
             (onManualEntry)="switchToManualEntry()">
           </lfx-user-search>
         </div>

--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.html
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.html
@@ -3,84 +3,132 @@
 
 <div class="registrant-form" data-testid="registrant-form-container">
   <form [formGroup]="form()" data-testid="registrant-form-element">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4" data-testid="registrant-form-fields-grid">
-      <!-- First Name -->
-      <div data-testid="registrant-form-firstname-field" class="flex flex-col gap-1">
-        <label for="first_name" class="text-sm font-medium text-gray-700">First Name</label>
-        <lfx-input-text
-          size="small"
-          [form]="form()"
-          control="first_name"
-          label="First Name"
-          placeholder="Enter first name"
-          data-testid="registrant-form-firstname-input">
-        </lfx-input-text>
+    <!-- User Search (shown when not in individual fields mode) -->
+    @if (!showIndividualFields()) {
+      <div class="flex flex-col gap-2">
+        <div data-testid="registrant-form-search-container">
+          <div class="flex items-center justify-between mb-2">
+            <label class="text-sm font-medium text-gray-700">Search for User</label>
+          </div>
+          <lfx-user-search
+            [form]="form()"
+            searchType="committee_member"
+            emailControl="email"
+            firstNameControl="first_name"
+            lastNameControl="last_name"
+            jobTitleControl="job_title"
+            organizationNameControl="org_name"
+            placeholder="Search user..."
+            styleClass="w-full"
+            class="w-full"
+            inputStyleClass="text-sm w-full"
+            panelStyleClass="text-sm w-full"
+            dataTestId="registrant-form-user-search"
+            (onUserSelect)="handleUserSelection($event)"
+            (onManualEntry)="switchToManualEntry()">
+          </lfx-user-search>
+        </div>
+        <div class="flex items-center justify-center gap-3 mt-3">
+          <span class="flex-1 border-t border-gray-200"></span>
+          <span class="text-xs text-gray-500 uppercase tracking-wider">or</span>
+          <span class="flex-1 border-t border-gray-200"></span>
+        </div>
+        <div class="text-center">
+          <button type="button" class="text-sm text-primary hover:text-primary-dark hover:underline transition-colors" (click)="switchToManualEntry()">
+            Enter details manually
+          </button>
+        </div>
       </div>
+    }
 
-      <!-- Last Name -->
-      <div data-testid="registrant-form-lastname-field" class="flex flex-col gap-1">
-        <label for="last_name" class="text-sm font-medium text-gray-700">Last Name</label>
-        <lfx-input-text
-          size="small"
-          [form]="form()"
-          control="last_name"
-          label="Last Name"
-          placeholder="Enter last name"
-          data-testid="registrant-form-lastname-input">
-        </lfx-input-text>
-      </div>
-
-      <!-- Email -->
-      <div class="md:col-span-2 flex flex-col gap-1" data-testid="registrant-form-email-field">
-        <label for="email" class="text-sm font-medium text-gray-700">Email</label>
-        <lfx-input-text
-          size="small"
-          [form]="form()"
-          control="email"
-          label="Email"
-          placeholder="Enter email address"
-          type="email"
-          data-testid="registrant-form-email-input">
-        </lfx-input-text>
-        @if (form().get('email')?.errors?.['required'] && form().get('email')?.touched && form().get('email')?.dirty) {
-          <p class="text-sm text-red-500">Email is required</p>
+    <!-- Individual Fields (shown when in individual fields mode) -->
+    @if (showIndividualFields()) {
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4" data-testid="registrant-form-fields-grid">
+        <!-- Back to Search Button -->
+        @if (!registrant()) {
+          <div class="md:col-span-2">
+            <button type="button" class="text-sm text-primary hover:underline" (click)="backToSearch()">← Back to search</button>
+          </div>
         }
-        @if (form().get('email')?.errors?.['email'] && form().get('email')?.touched && form().get('email')?.dirty) {
-          <p class="text-sm text-red-500">Invalid email address</p>
-        }
-      </div>
 
-      <!-- Job Title -->
-      <div data-testid="registrant-form-jobtitle-field" class="flex flex-col gap-1">
-        <label for="job_title" class="text-sm font-medium text-gray-700">Job Title</label>
-        <lfx-input-text
-          size="small"
-          [form]="form()"
-          control="job_title"
-          label="Job Title"
-          placeholder="Enter job title"
-          data-testid="registrant-form-jobtitle-input">
-        </lfx-input-text>
-      </div>
+        <!-- First Name -->
+        <div data-testid="registrant-form-firstname-field" class="flex flex-col gap-1">
+          <label for="first_name" class="text-sm font-medium text-gray-700">First Name</label>
+          <lfx-input-text
+            size="small"
+            [form]="form()"
+            control="first_name"
+            label="First Name"
+            placeholder="Enter first name"
+            data-testid="registrant-form-firstname-input">
+          </lfx-input-text>
+        </div>
 
-      <!-- Organization -->
-      <div data-testid="registrant-form-organization-field" class="flex flex-col gap-1">
-        <label for="org_name" class="text-sm font-medium text-gray-700">Organization</label>
-        <lfx-organization-search
-          [form]="form()"
-          nameControl="org_name"
-          placeholder="Search organizations..."
-          styleClass="w-full"
-          inputStyleClass="text-sm w-full"
-          panelStyleClass="text-sm w-full"
-          dataTestId="registrant-form-organization-input">
-        </lfx-organization-search>
-      </div>
+        <!-- Last Name -->
+        <div data-testid="registrant-form-lastname-field" class="flex flex-col gap-1">
+          <label for="last_name" class="text-sm font-medium text-gray-700">Last Name</label>
+          <lfx-input-text
+            size="small"
+            [form]="form()"
+            control="last_name"
+            label="Last Name"
+            placeholder="Enter last name"
+            data-testid="registrant-form-lastname-input">
+          </lfx-input-text>
+        </div>
 
-      <!-- Host Toggle -->
-      <div class="md:col-span-2 flex flex-col gap-1" data-testid="registrant-form-host-field">
-        <lfx-checkbox [form]="form()" control="host" label="Meeting Host" [binary]="true" data-testid="registrant-form-host-checkbox"> </lfx-checkbox>
+        <!-- Email -->
+        <div class="md:col-span-2 flex flex-col gap-1" data-testid="registrant-form-email-field">
+          <label for="email" class="text-sm font-medium text-gray-700">Email</label>
+          <lfx-input-text
+            size="small"
+            [form]="form()"
+            control="email"
+            label="Email"
+            placeholder="Enter email address"
+            type="email"
+            data-testid="registrant-form-email-input">
+          </lfx-input-text>
+          @if (form().get('email')?.errors?.['required'] && form().get('email')?.touched && form().get('email')?.dirty) {
+            <p class="text-sm text-red-500">Email is required</p>
+          }
+          @if (form().get('email')?.errors?.['email'] && form().get('email')?.touched && form().get('email')?.dirty) {
+            <p class="text-sm text-red-500">Invalid email address</p>
+          }
+        </div>
+
+        <!-- Job Title -->
+        <div data-testid="registrant-form-jobtitle-field" class="flex flex-col gap-1">
+          <label for="job_title" class="text-sm font-medium text-gray-700">Job Title</label>
+          <lfx-input-text
+            size="small"
+            [form]="form()"
+            control="job_title"
+            label="Job Title"
+            placeholder="Enter job title"
+            data-testid="registrant-form-jobtitle-input">
+          </lfx-input-text>
+        </div>
+
+        <!-- Organization -->
+        <div data-testid="registrant-form-organization-field" class="flex flex-col gap-1">
+          <label for="org_name" class="text-sm font-medium text-gray-700">Organization</label>
+          <lfx-organization-search
+            [form]="form()"
+            nameControl="org_name"
+            placeholder="Search organizations..."
+            styleClass="w-full"
+            inputStyleClass="text-sm w-full"
+            panelStyleClass="text-sm w-full"
+            dataTestId="registrant-form-organization-input">
+          </lfx-organization-search>
+        </div>
+
+        <!-- Host Toggle -->
+        <div class="md:col-span-2 flex flex-col gap-1" data-testid="registrant-form-host-field">
+          <lfx-checkbox [form]="form()" control="host" label="Meeting Host" [binary]="true" data-testid="registrant-form-host-checkbox"> </lfx-checkbox>
+        </div>
       </div>
-    </div>
+    }
   </form>
 </div>

--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.ts
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.ts
@@ -9,7 +9,7 @@ import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { UserSearchComponent } from '@components/user-search/user-search.component';
-import { MeetingRegistrant, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { MeetingRegistrant } from '@lfx-one/shared/interfaces';
 import { filter, take } from 'rxjs';
 
 @Component({
@@ -43,8 +43,7 @@ export class RegistrantFormComponent {
    * Handle user selection from search component
    * The form controls are already populated by the search component
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public handleUserSelection(_user: UserSearchResult): void {
+  public handleUserSelection(): void {
     // The search component has already populated the form controls
     // Now show the individual input fields
     this.showIndividualFields.set(true);

--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.ts
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-form/registrant-form.component.ts
@@ -2,21 +2,78 @@
 // SPDX-License-Identifier: MIT
 
 import { CommonModule } from '@angular/common';
-import { Component, input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
-import { MeetingRegistrant } from '@lfx-one/shared/interfaces';
+import { UserSearchComponent } from '@components/user-search/user-search.component';
+import { MeetingRegistrant, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { filter, take } from 'rxjs';
 
 @Component({
   selector: 'lfx-registrant-form',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, InputTextComponent, CheckboxComponent, OrganizationSearchComponent],
+  imports: [CommonModule, ReactiveFormsModule, InputTextComponent, CheckboxComponent, OrganizationSearchComponent, UserSearchComponent],
   templateUrl: './registrant-form.component.html',
 })
 export class RegistrantFormComponent {
   // Inputs
   public form = input.required<FormGroup>();
   public registrant = input<MeetingRegistrant | null>(null);
+
+  // State to track whether we're showing search or individual fields
+  public showIndividualFields = signal(false);
+
+  public constructor() {
+    // If we have an existing registrant, show individual fields immediately
+    // Using toObservable to specifically track only registrant changes
+    toObservable(this.registrant)
+      .pipe(
+        filter((registrant) => registrant !== null),
+        take(1)
+      )
+      .subscribe(() => {
+        this.showIndividualFields.set(true);
+      });
+  }
+
+  /**
+   * Handle user selection from search component
+   * The form controls are already populated by the search component
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public handleUserSelection(_user: UserSearchResult): void {
+    // The search component has already populated the form controls
+    // Now show the individual input fields
+    this.showIndividualFields.set(true);
+    this.form().markAsDirty();
+  }
+
+  /**
+   * Switch to manual entry mode when user clicks "Enter details manually"
+   */
+  public switchToManualEntry(): void {
+    // Clear the form for manual entry
+    const hostValue = this.form().get('host')?.value; // Preserve host checkbox state
+    this.form().reset();
+    this.form().get('host')?.setValue(hostValue);
+
+    // Show individual fields for manual entry
+    this.showIndividualFields.set(true);
+  }
+
+  /**
+   * Go back to search mode
+   */
+  public backToSearch(): void {
+    // Reset form but preserve host checkbox
+    const hostValue = this.form().get('host')?.value;
+    this.form().reset();
+    this.form().get('host')?.setValue(hostValue);
+
+    // Switch back to search mode
+    this.showIndividualFields.set(false);
+  }
 }

--- a/apps/lfx-one/src/app/shared/components/autocomplete/autocomplete.component.html
+++ b/apps/lfx-one/src/app/shared/components/autocomplete/autocomplete.component.html
@@ -25,5 +25,15 @@
     <ng-template pTemplate="empty" *ngIf="emptyTemplate">
       <ng-container *ngTemplateOutlet="emptyTemplate"></ng-container>
     </ng-template>
+
+    <!-- Item template -->
+    <ng-template pTemplate="item" let-item *ngIf="itemTemplate">
+      <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
+    </ng-template>
+
+    <!-- Footer template -->
+    <ng-template pTemplate="footer" *ngIf="footerTemplate">
+      <ng-container *ngTemplateOutlet="footerTemplate"></ng-container>
+    </ng-template>
   </p-autocomplete>
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/autocomplete/autocomplete.component.ts
+++ b/apps/lfx-one/src/app/shared/components/autocomplete/autocomplete.component.ts
@@ -14,6 +14,9 @@ import { AutoCompleteCompleteEvent, AutoCompleteModule, AutoCompleteSelectEvent 
 export class AutocompleteComponent {
   // Template reference for content projection
   @ContentChild('empty', { static: false, descendants: false }) public emptyTemplate?: TemplateRef<any>;
+  @ContentChild('item', { static: false, descendants: false }) public itemTemplate?: TemplateRef<any>;
+  @ContentChild('footer', { static: false, descendants: false }) public footerTemplate?: TemplateRef<any>;
+
   public form = input.required<FormGroup>();
   public control = input.required<string>();
   public placeholder = input<string>();
@@ -21,7 +24,7 @@ export class AutocompleteComponent {
   public styleClass = input<string>();
   public inputStyleClass = input<string>();
   public panelStyleClass = input<string>();
-  public delay = input<number>();
+  public delay = input<number>(300);
   public minLength = input<number>(1);
   public dataTestId = input<string>();
   public optionLabel = input<string>();

--- a/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/organization-search/organization-search.component.ts
@@ -7,7 +7,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { normalizeToUrl, OrganizationSuggestion } from '@lfx-one/shared';
 import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
-import { catchError, distinctUntilChanged, of, startWith, switchMap } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, of, startWith, switchMap } from 'rxjs';
 
 import { OrganizationService } from '../../services/organization.service';
 import { AutocompleteComponent } from '../autocomplete/autocomplete.component';
@@ -49,6 +49,7 @@ export class OrganizationSearchComponent {
     const searchResults$ = this.organizationForm.get('organizationSearch')!.valueChanges.pipe(
       startWith(''),
       distinctUntilChanged(),
+      debounceTime(300),
       switchMap((searchTerm: string | null) => {
         const trimmedTerm = searchTerm?.trim() || '';
 

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.html
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.html
@@ -1,0 +1,45 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-autocomplete
+  [form]="userSearchForm"
+  control="userSearch"
+  [placeholder]="placeholder()"
+  [suggestions]="suggestions()"
+  [styleClass]="styleClass()"
+  [inputStyleClass]="inputStyleClass()"
+  [panelStyleClass]="panelStyleClass()"
+  [dataTestId]="dataTestId()"
+  optionLabel="displayName"
+  size="small"
+  appendTo="body"
+  (completeMethod)="onSearchComplete($event)"
+  (onSelect)="onUserSelected($event)"
+  (onClear)="onSearchClear()">
+  <ng-template #item let-user>
+    <div class="w-full flex justify-between items-center gap-2">
+      <div class="flex flex-col">
+        <div class="text-sm flex gap-1 items-center">
+          <span> {{ user.first_name }} {{ user.last_name }} </span>
+          @if (user.organization?.name) {
+            <span class="text-xs text-gray-500"> ({{ user.organization?.name }}) </span>
+          }
+        </div>
+        <span class="text-xs text-gray-500">{{ user.email }}</span>
+      </div>
+    </div>
+  </ng-template>
+  <!-- Empty template -->
+  <ng-template #empty>
+    <div class="p-3 text-center">
+      <p class="text-sm text-gray-600">No users found</p>
+    </div>
+  </ng-template>
+
+  <!-- Footer template - always shown -->
+  <ng-template #footer>
+    <div class="p-2 border-t border-gray-200 text-center">
+      <button type="button" class="text-sm text-primary hover:underline" (click)="onEnterManually()">Enter details manually</button>
+    </div>
+  </ng-template>
+</lfx-autocomplete>

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
@@ -152,7 +152,7 @@ export class UserSearchComponent {
     // Update username control
     const usernameControlName = this.usernameControl();
     if (usernameControlName && parentForm.get(usernameControlName)) {
-      parentForm.get(usernameControlName)?.setValue(selectedUser.username);
+      parentForm.get(usernameControlName)?.setValue(selectedUser.username || null);
     }
 
     // Clear the search field to show that selection is complete

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
@@ -1,0 +1,198 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CommonModule } from '@angular/common';
+import { Component, effect, inject, input, output, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { UserSearchResult } from '@lfx-one/shared/interfaces';
+import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
+import { catchError, debounceTime, distinctUntilChanged, map, of, startWith, switchMap } from 'rxjs';
+
+import { SearchService } from '../../services/search.service';
+import { AutocompleteComponent } from '../autocomplete/autocomplete.component';
+
+@Component({
+  selector: 'lfx-user-search',
+  imports: [AutocompleteComponent, ReactiveFormsModule, CommonModule],
+  templateUrl: './user-search.component.html',
+})
+export class UserSearchComponent {
+  private readonly searchService = inject(SearchService);
+
+  // Required inputs
+  public form = input.required<FormGroup>();
+  public searchType = input.required<'committee_member' | 'meeting_registrant'>();
+
+  // Optional inputs for form control names
+  public emailControl = input<string>();
+  public firstNameControl = input<string>();
+  public lastNameControl = input<string>();
+  public jobTitleControl = input<string>();
+  public organizationNameControl = input<string>();
+  public organizationWebsiteControl = input<string>();
+  public usernameControl = input<string>();
+
+  // UI customization inputs
+  public placeholder = input<string>('Search users...');
+  public styleClass = input<string>();
+  public inputStyleClass = input<string>();
+  public panelStyleClass = input<string>();
+  public dataTestId = input<string>('user-search');
+  public disabled = input<boolean>(false);
+
+  // Outputs
+  public readonly onUserSelect = output<UserSearchResult>();
+  public readonly onManualEntry = output<void>();
+
+  // Internal form for the search input
+  protected readonly userSearchForm = new FormGroup({
+    userSearch: new FormControl<string>(''),
+  });
+
+  // Initialize suggestions as a signal based on search query changes
+  protected suggestions: Signal<Array<UserSearchResult & { displayName: string }>>;
+
+  public constructor() {
+    // Initialize suggestions signal that reacts to search query changes
+    const searchResults$ = this.userSearchForm.get('userSearch')!.valueChanges.pipe(
+      startWith(''),
+      distinctUntilChanged(),
+      debounceTime(300),
+      switchMap((searchTerm: string | null) => {
+        const trimmedTerm = searchTerm?.trim() || '';
+
+        // Only fetch suggestions when user types at least 2 characters
+        if (trimmedTerm.length < 2) {
+          return of([]);
+        }
+
+        // Use the search type from input
+        return this.searchService.searchUsers(trimmedTerm, this.searchType());
+      }),
+      map((users: UserSearchResult[]) => {
+        // Add displayName field for the autocomplete to show
+        return users.map((user) => ({
+          ...user,
+          displayName: this.formatUserDisplay(user),
+        }));
+      }),
+      catchError((error) => {
+        console.error('Error searching users:', error);
+        return of([]);
+      })
+    );
+
+    this.suggestions = toSignal(searchResults$, {
+      initialValue: [],
+    });
+
+    // Effect to sync the search input with the parent form's email control if provided
+    effect(() => {
+      const parentForm = this.form();
+      const emailControlName = this.emailControl();
+
+      if (parentForm && emailControlName) {
+        const emailControlValue = parentForm.get(emailControlName)?.value;
+
+        if (emailControlValue && emailControlValue.trim()) {
+          this.userSearchForm.get('userSearch')?.setValue(emailControlValue, { emitEvent: false });
+        }
+      }
+    });
+  }
+
+  public onSearchComplete(event: AutoCompleteCompleteEvent): void {
+    // Update the search form value which will trigger the observable
+    this.userSearchForm.get('userSearch')?.setValue(event.query);
+  }
+
+  public onUserSelected(event: AutoCompleteSelectEvent): void {
+    const selectedUser = event.value as UserSearchResult;
+
+    // Update form controls if they are specified
+    const parentForm = this.form();
+
+    // Update email control
+    const emailControlName = this.emailControl();
+    if (emailControlName && parentForm.get(emailControlName)) {
+      parentForm.get(emailControlName)?.setValue(selectedUser.email);
+    }
+
+    // Update first name control
+    const firstNameControlName = this.firstNameControl();
+    if (firstNameControlName && parentForm.get(firstNameControlName)) {
+      parentForm.get(firstNameControlName)?.setValue(selectedUser.first_name);
+    }
+
+    // Update last name control
+    const lastNameControlName = this.lastNameControl();
+    if (lastNameControlName && parentForm.get(lastNameControlName)) {
+      parentForm.get(lastNameControlName)?.setValue(selectedUser.last_name);
+    }
+
+    // Update job title control
+    const jobTitleControlName = this.jobTitleControl();
+    if (jobTitleControlName && parentForm.get(jobTitleControlName)) {
+      parentForm.get(jobTitleControlName)?.setValue(selectedUser.job_title);
+    }
+
+    // Update organization name control
+    const orgNameControlName = this.organizationNameControl();
+    if (orgNameControlName && parentForm.get(orgNameControlName)) {
+      parentForm.get(orgNameControlName)?.setValue(selectedUser.organization?.name || null);
+    }
+
+    // Update organization website control
+    const orgWebsiteControlName = this.organizationWebsiteControl();
+    if (orgWebsiteControlName && parentForm.get(orgWebsiteControlName)) {
+      parentForm.get(orgWebsiteControlName)?.setValue(selectedUser.organization?.website || null);
+    }
+
+    // Update username control
+    const usernameControlName = this.usernameControl();
+    if (usernameControlName && parentForm.get(usernameControlName)) {
+      parentForm.get(usernameControlName)?.setValue(selectedUser.username);
+    }
+
+    // Clear the search field to show that selection is complete
+    this.userSearchForm.get('userSearch')?.setValue('', { emitEvent: false });
+
+    // Emit the selected user - parent component will handle showing individual fields
+    this.onUserSelect.emit(selectedUser);
+  }
+
+  public onSearchClear(): void {
+    this.userSearchForm.get('userSearch')?.setValue('');
+
+    // Clear all form controls if they are specified
+    const parentForm = this.form();
+    const controlsToClear = [
+      this.emailControl(),
+      this.firstNameControl(),
+      this.lastNameControl(),
+      this.jobTitleControl(),
+      this.organizationNameControl(),
+      this.organizationWebsiteControl(),
+      this.usernameControl(),
+    ];
+
+    controlsToClear.forEach((controlName) => {
+      if (controlName && parentForm.get(controlName)) {
+        parentForm.get(controlName)?.setValue(null);
+      }
+    });
+  }
+
+  public onEnterManually(): void {
+    // Emit event to let parent component handle manual entry
+    this.onManualEntry.emit();
+  }
+
+  private formatUserDisplay(user: UserSearchResult): string {
+    const name = `${user.first_name} ${user.last_name}`;
+    const org = user.organization?.name ? ` - ${user.organization.name}` : '';
+    const email = ` (${user.email})`;
+    return `${name}${org}${email}`;
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/search.service.ts
+++ b/apps/lfx-one/src/app/shared/services/search.service.ts
@@ -1,0 +1,51 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { UserSearchParams, UserSearchResponse, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { catchError, map, Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SearchService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Search for users (meeting registrants or committee members)
+   */
+  public searchUsers(name: string, type: 'committee_member' | 'meeting_registrant'): Observable<UserSearchResult[]> {
+    if (!name || !type) {
+      return of([]);
+    }
+
+    const params = new HttpParams().set('name', name).set('type', type).set('limit', '20');
+
+    return this.http.get<UserSearchResponse>('/api/search/users', { params }).pipe(
+      map((response) => response.results || []),
+      catchError((error) => {
+        console.error('Error searching users:', error);
+        return of([]);
+      })
+    );
+  }
+
+  /**
+   * Search for users with custom parameters
+   */
+  public searchUsersAdvanced(params: UserSearchParams): Observable<UserSearchResponse> {
+    const httpParams = new HttpParams()
+      .set('name', params.name)
+      .set('type', params.type)
+      .set('limit', (params.limit || 20).toString())
+      .set('offset', (params.offset || 0).toString());
+
+    return this.http.get<UserSearchResponse>('/api/search/users', { params: httpParams }).pipe(
+      catchError((error) => {
+        console.error('Error searching users:', error);
+        return of({ results: [], total: 0, has_more: false });
+      })
+    );
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/search.service.ts
+++ b/apps/lfx-one/src/app/shared/services/search.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { UserSearchParams, UserSearchResponse, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { UserSearchResponse, UserSearchResult } from '@lfx-one/shared/interfaces';
 import { catchError, map, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -20,31 +20,20 @@ export class SearchService {
       return of([]);
     }
 
-    const params = new HttpParams().set('name', name).set('type', type).set('limit', '20');
+    let params = new HttpParams().set('type', type).set('limit', '20');
+
+    // if name is an email, search for users by email
+    if (name.includes('@')) {
+      params = params.set('tags', `email:${name}`);
+    } else {
+      params = params.set('name', name);
+    }
 
     return this.http.get<UserSearchResponse>('/api/search/users', { params }).pipe(
       map((response) => response.results || []),
       catchError((error) => {
         console.error('Error searching users:', error);
         return of([]);
-      })
-    );
-  }
-
-  /**
-   * Search for users with custom parameters
-   */
-  public searchUsersAdvanced(params: UserSearchParams): Observable<UserSearchResponse> {
-    const httpParams = new HttpParams()
-      .set('name', params.name)
-      .set('type', params.type)
-      .set('limit', (params.limit || 20).toString())
-      .set('offset', (params.offset || 0).toString());
-
-    return this.http.get<UserSearchResponse>('/api/search/users', { params: httpParams }).pipe(
-      catchError((error) => {
-        console.error('Error searching users:', error);
-        return of({ results: [], total: 0, has_more: false });
       })
     );
   }

--- a/apps/lfx-one/src/server/controllers/search.controller.ts
+++ b/apps/lfx-one/src/server/controllers/search.controller.ts
@@ -1,0 +1,101 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { UserSearchParams } from '@lfx-one/shared/interfaces';
+import { NextFunction, Request, Response } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { Logger } from '../helpers/logger';
+import { SearchService } from '../services/search.service';
+
+/**
+ * Controller for handling search HTTP requests
+ */
+export class SearchController {
+  private searchService: SearchService = new SearchService();
+
+  /**
+   * GET /search/users
+   * Searches for users across meeting registrants and committee members
+   */
+  public async searchUsers(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { name, type } = req.query;
+    const startTime = Logger.start(req, 'search_users', {
+      has_name: !!name,
+      has_type: !!type,
+    });
+
+    try {
+      // Validate required parameters
+      if (!name || typeof name !== 'string') {
+        Logger.error(req, 'search_users', startTime, new Error('Missing or invalid name parameter'), {
+          name_type: typeof name,
+        });
+
+        const validationError = ServiceValidationError.forField('name', 'Name parameter is required and must be a string', {
+          operation: 'search_users',
+          service: 'search_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
+      if (!type || typeof type !== 'string') {
+        Logger.error(req, 'search_users', startTime, new Error('Missing or invalid type parameter'), {
+          type_type: typeof type,
+        });
+
+        const validationError = ServiceValidationError.forField('type', 'Type parameter is required and must be a string', {
+          operation: 'search_users',
+          service: 'search_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
+      // Validate type value
+      if (!['committee_member', 'meeting_registrant'].includes(type)) {
+        Logger.error(req, 'search_users', startTime, new Error('Invalid type value'), {
+          provided_type: type,
+        });
+
+        const validationError = ServiceValidationError.forField('type', 'Type must be either "committee_member" or "meeting_registrant"', {
+          operation: 'search_users',
+          service: 'search_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
+      // Build search parameters
+      const searchParams: UserSearchParams = {
+        name,
+        type: type as 'committee_member' | 'meeting_registrant',
+        limit: req.query['limit'] ? parseInt(req.query['limit'] as string, 10) : undefined,
+        offset: req.query['offset'] ? parseInt(req.query['offset'] as string, 10) : undefined,
+      };
+
+      // Perform the search
+      const results = await this.searchService.searchUsers(req, searchParams);
+
+      Logger.success(req, 'search_users', startTime, {
+        result_count: results.results.length,
+        has_more: results.has_more,
+      });
+
+      res.json(results);
+    } catch (error) {
+      Logger.error(req, 'search_users', startTime, error, {
+        name,
+        type,
+      });
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/search.route.ts
+++ b/apps/lfx-one/src/server/routes/search.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { SearchController } from '../controllers/search.controller';
+
+const router = Router();
+const searchController = new SearchController();
+
+// User search route
+router.get('/users', (req, res, next) => searchController.searchUsers(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -24,6 +24,7 @@ import pastMeetingsRouter from './routes/past-meetings.route';
 import profileRouter from './routes/profile.route';
 import projectsRouter from './routes/projects.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
+import searchRouter from './routes/search.route';
 
 if (process.env['NODE_ENV'] !== 'production') {
   dotenv.config();
@@ -203,6 +204,7 @@ app.use('/api/meetings', meetingsRouter);
 app.use('/api/organizations', organizationsRouter);
 app.use('/api/past-meetings', pastMeetingsRouter);
 app.use('/api/profile', profileRouter);
+app.use('/api/search', searchRouter);
 
 // Add API error handler middleware
 app.use('/api/*', apiErrorHandler);

--- a/apps/lfx-one/src/server/services/search.service.ts
+++ b/apps/lfx-one/src/server/services/search.service.ts
@@ -22,7 +22,8 @@ export class SearchService {
   public async searchUsers(req: Request, params: UserSearchParams): Promise<UserSearchResponse> {
     const queryParams = {
       v: 1,
-      name: params.name,
+      ...(params.name ? { name: params.name } : {}),
+      ...(params.tags ? { tags: params.tags } : {}),
       type: params.type,
       limit: params.limit || 50,
       offset: params.offset || 0,

--- a/apps/lfx-one/src/server/services/search.service.ts
+++ b/apps/lfx-one/src/server/services/search.service.ts
@@ -1,0 +1,90 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CommitteeMember, MeetingRegistrant, QueryServiceResponse, UserSearchParams, UserSearchResponse, UserSearchResult } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { MicroserviceProxyService } from './microservice-proxy.service';
+
+/**
+ * Service for handling search operations across different resource types
+ */
+export class SearchService {
+  private microserviceProxy: MicroserviceProxyService;
+
+  public constructor() {
+    this.microserviceProxy = new MicroserviceProxyService();
+  }
+
+  /**
+   * Searches for users across meeting registrants and committee members
+   */
+  public async searchUsers(req: Request, params: UserSearchParams): Promise<UserSearchResponse> {
+    const queryParams = {
+      v: 1,
+      name: params.name,
+      type: params.type,
+      limit: params.limit || 50,
+      offset: params.offset || 0,
+    };
+
+    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant | CommitteeMember>>(
+      req,
+      'LFX_V2_SERVICE',
+      '/query/resources',
+      'GET',
+      queryParams
+    );
+
+    // Transform the resources to UserSearchResult format
+    const results: UserSearchResult[] = resources.map((resource) => {
+      const data = resource.data;
+
+      if (params.type === 'meeting_registrant') {
+        const registrant = data as MeetingRegistrant;
+        return {
+          uid: registrant.uid,
+          email: registrant.email,
+          first_name: registrant.first_name,
+          last_name: registrant.last_name,
+          job_title: registrant.job_title,
+          organization: registrant.org_name
+            ? {
+                name: registrant.org_name,
+                website: null,
+              }
+            : null,
+          committee: null,
+          type: 'meeting_registrant',
+          username: registrant.username,
+        };
+      }
+      const member = data as CommitteeMember;
+      return {
+        uid: member.uid,
+        email: member.email,
+        first_name: member.first_name,
+        last_name: member.last_name,
+        job_title: member.job_title || null,
+        organization: member.organization
+          ? {
+              name: member.organization.name,
+              website: member.organization.website || null,
+            }
+          : null,
+        committee: {
+          uid: member.committee_uid,
+          name: member.committee_name,
+        },
+        type: 'committee_member',
+        username: member.username || null,
+      };
+    });
+
+    return {
+      results,
+      total: results.length,
+      has_more: results.length === queryParams.limit,
+    };
+  }
+}

--- a/packages/shared/src/interfaces/search.interface.ts
+++ b/packages/shared/src/interfaces/search.interface.ts
@@ -82,7 +82,9 @@ export interface UserSearchResult {
  */
 export interface UserSearchParams {
   /** Search query string (user name) */
-  name: string;
+  name?: string;
+  /** Search query string (user email) */
+  tags?: string;
   /** Type of resource to search */
   type: 'committee_member' | 'meeting_registrant';
   /** Maximum number of results to return (optional) */

--- a/packages/shared/src/interfaces/search.interface.ts
+++ b/packages/shared/src/interfaces/search.interface.ts
@@ -40,3 +40,66 @@ export interface ProjectSearchParams {
   /** Number of results to skip (for pagination) */
   offset?: number;
 }
+
+/**
+ * User search result combining MeetingRegistrant and CommitteeMember
+ * @description Common user information from either meeting registrants or committee members
+ */
+export interface UserSearchResult {
+  /** Unique identifier for the user record */
+  uid: string;
+  /** User's email address */
+  email: string;
+  /** User's first name */
+  first_name: string;
+  /** User's last name */
+  last_name: string;
+  /** User's job title */
+  job_title: string | null;
+  /** User's organization information */
+  organization: {
+    /** Organization name */
+    name: string;
+    /** Organization website URL */
+    website?: string | null;
+  } | null;
+  /** Committee information (if user is a committee member) */
+  committee?: {
+    /** Committee unique identifier */
+    uid: string;
+    /** Committee name */
+    name: string;
+  } | null;
+  /** Source type of the user record */
+  type: 'meeting_registrant' | 'committee_member';
+  /** User's LFID username (optional) */
+  username?: string | null;
+}
+
+/**
+ * Parameters for user search queries
+ * @description Query parameters for searching users across meeting registrants and committee members
+ */
+export interface UserSearchParams {
+  /** Search query string (user name) */
+  name: string;
+  /** Type of resource to search */
+  type: 'committee_member' | 'meeting_registrant';
+  /** Maximum number of results to return (optional) */
+  limit?: number;
+  /** Number of results to skip for pagination (optional) */
+  offset?: number;
+}
+
+/**
+ * Response structure for user search API
+ * @description Container for user search results with metadata
+ */
+export interface UserSearchResponse {
+  /** Array of user search results */
+  results: UserSearchResult[];
+  /** Total number of matching users */
+  total?: number;
+  /** Whether there are more results available */
+  has_more?: boolean;
+}

--- a/packages/shared/src/utils/form.utils.ts
+++ b/packages/shared/src/utils/form.utils.ts
@@ -13,7 +13,17 @@ export function generateTempId(): string {
 /**
  * Marks all form controls as touched to trigger validation display
  */
-export function markFormControlsAsTouched(form: FormGroup): void {
+export function markFormControlsAsTouched(form: FormGroup, onlySelf: boolean = false, emitEvent: boolean = false): void {
   form.markAllAsTouched();
-  form.updateValueAndValidity({ onlySelf: false, emitEvent: false });
+  form.updateValueAndValidity({ onlySelf, emitEvent });
+}
+
+/**
+ * Update value and validity of all form controls
+ */
+export function updateFormControls(form: FormGroup, onlySelf: boolean = false, emitEvent: boolean = false): void {
+  Object.keys(form.controls).forEach((key) => {
+    const control = form.get(key);
+    control?.updateValueAndValidity({ onlySelf, emitEvent });
+  });
 }


### PR DESCRIPTION
## Description
This PR implements comprehensive user search functionality for meeting registrants, allowing users to search and select existing registrants or enter details manually.

## JIRA Tickets
- [LFXV2-622](https://linuxfoundation.atlassian.net/browse/LFXV2-622): Implement backend user search API
- [LFXV2-623](https://linuxfoundation.atlassian.net/browse/LFXV2-623): Create reusable user search component
- [LFXV2-624](https://linuxfoundation.atlassian.net/browse/LFXV2-624): Enhance autocomplete component with template support
- [LFXV2-625](https://linuxfoundation.atlassian.net/browse/LFXV2-625): Integrate user search into registrant form

## Changes Made

### Backend
- Created SearchService for querying meeting registrants and committee members
- Added search controller and routes at `/api/search/users`
- Integrated with query microservice for resource fetching
- Unified response format for both registrant and member types

### Frontend Components
- **User Search Component**: Reusable autocomplete search with debouncing
- **Autocomplete Enhancements**: Added custom item and footer template support
- **Registrant Form Integration**: Toggle between search and manual entry modes

## Features
- 🔍 Search for existing users (meeting registrants or committee members)
- ⚡ Debounced search with minimum 2 characters
- 📝 Auto-populate form fields on user selection
- ✏️ Manual entry option always available
- 🔄 Switch between search and manual modes
- ✅ Proper email validation on selection

## Testing Instructions
1. Navigate to a meeting's manage page
2. Go to the Registrants tab
3. Click "Add Registrant"
4. Try searching for a user by typing at least 2 characters
5. Select a user from the dropdown - form should populate
6. Try "Enter details manually" option from footer
7. Verify "Back to search" functionality
8. Test form validation after user selection

## Screenshots
- User search with results displayed
- Manual entry option in footer
- Individual fields after selection
- Styled divider for manual entry link

[LFXV2-622]: https://linuxfoundation.atlassian.net/browse/LFXV2-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-623]: https://linuxfoundation.atlassian.net/browse/LFXV2-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-624]: https://linuxfoundation.atlassian.net/browse/LFXV2-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-625]: https://linuxfoundation.atlassian.net/browse/LFXV2-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ