### PR TITLE
feat(meetings): add resend invitation functionality for registrants

### DIFF
--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-modal/registrant-modal.component.html
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-modal/registrant-modal.component.html
@@ -8,14 +8,27 @@
   <!-- Action Buttons -->
   <div class="flex border-t border-gray-200 pt-4 justify-between items-center" data-testid="registrant-modal-actions">
     @if (isEditMode) {
-      <lfx-button
-        label="Delete Registrant"
-        severity="danger"
-        size="small"
-        type="button"
-        (onClick)="onDeleteRegistrant()"
-        data-testid="registrant-modal-delete-button">
-      </lfx-button>
+      <div class="flex gap-2 items-center">
+        <lfx-button
+          label="Delete Registrant"
+          severity="danger"
+          size="small"
+          type="button"
+          (onClick)="onDeleteRegistrant()"
+          data-testid="registrant-modal-delete-button">
+        </lfx-button>
+        <lfx-button
+          label="Resend Invitation"
+          icon="fa-light fa-paper-plane"
+          severity="secondary"
+          size="small"
+          type="button"
+          [loading]="resendingInvitation()"
+          [disabled]="resendingInvitation()"
+          (onClick)="onResendInvitation()"
+          data-testid="registrant-modal-resend-button">
+        </lfx-button>
+      </div>
     } @else {
       <!-- Add More Registrants Option (only in add mode) -->
       <lfx-checkbox

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -409,6 +409,16 @@ export class MeetingService {
     return new FormGroup(controls);
   }
 
+  public resendMeetingInvitation(meetingUid: string, registrantId: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`/api/meetings/${meetingUid}/registrants/${registrantId}/resend`, {}).pipe(
+      take(1),
+      catchError((error) => {
+        console.error('Failed to resend meeting invitation:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
   private readFileAsBase64(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();

--- a/apps/lfx-one/src/server/routes/meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/meetings.route.ts
@@ -45,6 +45,9 @@ router.put('/:uid/registrants', (req, res, next) => meetingController.updateMeet
 // DELETE /meetings/:uid/registrants - delete registrants (handles single or multiple)
 router.delete('/:uid/registrants', (req, res, next) => meetingController.deleteMeetingRegistrants(req, res, next));
 
+// POST /meetings/:uid/registrants/:registrantId/resend - resend invitation to specific registrant
+router.post('/:uid/registrants/:registrantId/resend', (req, res, next) => meetingController.resendMeetingInvitation(req, res, next));
+
 router.post('/:uid/attachments/upload', async (req: Request, res: Response, next: NextFunction) => {
   const startTime = Date.now();
   const meetingId = req.params['uid'];

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -392,6 +392,28 @@ export class MeetingService {
   }
 
   /**
+   * Resends a meeting invitation to a specific registrant
+   */
+  public async resendMeetingInvitation(req: Request, meetingUid: string, registrantId: string): Promise<void> {
+    try {
+      // Call the LFX API endpoint for resending invitation
+      await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/meetings/${meetingUid}/registrants/${registrantId}/resend`, 'POST');
+
+      // Log the successful operation
+      Logger.success(req, 'resend_meeting_invitation', Date.now(), {
+        meeting_uid: meetingUid,
+        registrant_id: registrantId,
+      });
+    } catch (error) {
+      Logger.error(req, 'resend_meeting_invitation', Date.now(), error, {
+        meeting_uid: meetingUid,
+        registrant_id: registrantId,
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Fetches meeting join URL by meeting UID
    */
   public async getMeetingJoinUrl(req: Request, meetingUid: string): Promise<MeetingJoinURL> {


### PR DESCRIPTION
## Summary
- Add resend invitation functionality for meeting registrants
- Allows organizers to resend invitations to specific registrants from the modal
- Implements proper error handling and user feedback

## Changes
- **Backend**: New BFF endpoint `POST /meetings/:uid/registrants/:registrantId/resend`
- **Frontend**: Resend button with confirmation dialog in registrant modal
- **UX**: Loading states, success/error messages, FontAwesome paper-plane icon
- **Architecture**: Follows existing patterns for API integration and error handling

## Testing
- Added data-testid attributes for E2E testing
- Proper validation and error handling
- Confirmation dialog prevents accidental sends
- Loading states provide clear user feedback

## Demo
https://github.com/user-attachments/assets/8cabc514-f709-45a9-a32b-c06ef1601201


## Jira References
- [LFXV2-632](https://linuxfoundation.atlassian.net/browse/LFXV2-632)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-632]: https://linuxfoundation.atlassian.net/browse/LFXV2-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ