### PR TITLE
fix(profile): add scope for updating profile

### DIFF
--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -160,7 +160,7 @@ const authConfig: ConfigParams = {
   authorizationParams: {
     response_type: 'code',
     audience: process.env['PCC_AUTH0_AUDIENCE'] || 'https://example.com',
-    scope: 'openid email profile access:api offline_access',
+    scope: 'openid email profile access:api offline_access update:current_user_metadata',
   },
   clientSecret: process.env['PCC_AUTH0_CLIENT_SECRET'] || 'bar',
   routes: {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -919,7 +919,7 @@ const authConfig: ConfigParams = {
   authorizationParams: {
     response_type: 'code',
     audience: process.env['PCC_AUTH0_AUDIENCE'] || 'https://example.com',
-    scope: 'openid email profile api offline_access',
+    scope: 'openid email profile api offline_access update:current_user_metadata',
   },
   clientSecret: process.env['PCC_AUTH0_CLIENT_SECRET'] || 'bar',
 };


### PR DESCRIPTION
This pull request updates the OAuth scope configuration to include the ability to update the current user's metadata. This change is applied both in the server configuration and the architecture documentation to ensure consistency.

Authentication scope update:

* Added the `update:current_user_metadata` permission to the `scope` parameter in the `authConfig` object in `server.ts` to enable updating user metadata.
* Updated the documented `scope` in `architecture.md` to reflect the new permission, keeping documentation in sync with the codebase.