### PR TITLE
feat(analytics): integrate LF Segment analytics for user tracking

### DIFF
--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1,0 +1,188 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterNextRender, DestroyRef, inject, Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router } from '@angular/router';
+import { environment } from '@environments/environment';
+import { LfxSegmentAnalytics, LfxSegmentAnalyticsClass } from '@lfx-one/shared/interfaces';
+import { filter } from 'rxjs';
+
+declare global {
+  interface Window {
+    LfxAnalytics?: {
+      LfxSegmentsAnalytics: LfxSegmentAnalyticsClass;
+    };
+  }
+}
+
+/**
+ * Analytics service for Segment integration
+ * Uses Angular 19's afterNextRender for SSR-safe script loading
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AnalyticsService {
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private scriptLoaded = false;
+  private analyticsReady = false;
+  private analytics?: LfxSegmentAnalytics;
+  private identifyQueue: Array<{ user: unknown }> = [];
+
+  /**
+   * Initialize the analytics service - should be called from app component
+   */
+  public initialize(): void {
+    // SSR-safe initialization using afterNextRender
+    afterNextRender(() => {
+      this.loadSegmentScript();
+      this.setupRouteTracking();
+    });
+  }
+
+  /**
+   * Track a page view
+   * @param pageName Page name
+   * @param properties Optional page properties
+   */
+  public trackPage(pageName: string, properties?: Record<string, unknown>): void {
+    if (!this.analyticsReady || !this.analytics) {
+      return;
+    }
+
+    try {
+      this.analytics.page(pageName, properties);
+    } catch (error) {
+      console.error('Error tracking page with Segment:', error);
+    }
+  }
+
+  /**
+   * Track a custom event
+   * @param eventName Event name
+   * @param properties Event properties
+   */
+  public trackEvent(eventName: string, properties?: Record<string, unknown>): void {
+    if (!this.analyticsReady || !this.analytics) {
+      return;
+    }
+
+    try {
+      this.analytics.track(eventName, properties);
+    } catch (error) {
+      console.error('Error tracking event with Segment:', error);
+    }
+  }
+
+  /**
+   * Identify an Auth0 user with Segment
+   * @param auth0User Auth0 user object
+   */
+  public identifyUser(auth0User: unknown): void {
+    // If analytics is not ready yet, queue the identify call
+    if (!this.analyticsReady || !this.analytics) {
+      this.identifyQueue.push({ user: auth0User });
+      return;
+    }
+
+    try {
+      this.analytics.identifyAuth0User(auth0User);
+    } catch (error) {
+      console.error('Error identifying user with Segment:', error);
+    }
+  }
+
+  /**
+   * Load Segment script from CDN
+   */
+  private loadSegmentScript(): void {
+    if (!environment.segment?.enabled || this.scriptLoaded) {
+      return;
+    }
+
+    try {
+      const script = document.createElement('script');
+      script.src = environment.segment.cdnUrl;
+      script.async = true;
+      script.defer = true;
+
+      script.onload = () => {
+        this.scriptLoaded = true;
+        this.waitForAnalytics();
+      };
+
+      script.onerror = (error) => {
+        console.error('Failed to load Segment analytics script:', error);
+      };
+
+      document.head.appendChild(script);
+    } catch (error) {
+      console.error('Error initializing Segment:', error);
+    }
+  }
+
+  /**
+   * Wait for analytics object to be available and initialize it
+   */
+  private async waitForAnalytics(): Promise<void> {
+    const maxAttempts = 100; // 10 seconds max wait
+    let attempts = 0;
+
+    while (attempts < maxAttempts) {
+      if (window.LfxAnalytics?.LfxSegmentsAnalytics) {
+        this.analytics = window.LfxAnalytics.LfxSegmentsAnalytics.getInstance();
+
+        try {
+          await this.analytics.init();
+          this.analyticsReady = true;
+
+          // Process any queued identify calls
+          this.processIdentifyQueue();
+          return;
+        } catch (error) {
+          console.error('Error initializing LfxSegmentsAnalytics:', error);
+          return;
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      attempts++;
+    }
+
+    console.error('LfxSegmentsAnalytics not available after timeout');
+  }
+
+  /**
+   * Process queued identify calls
+   */
+  private processIdentifyQueue(): void {
+    while (this.identifyQueue.length > 0) {
+      const item = this.identifyQueue.shift();
+      if (item) {
+        this.identifyUser(item.user);
+      }
+    }
+  }
+
+  /**
+   * Set up automatic page tracking on route navigation
+   */
+  private setupRouteTracking(): void {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((event: NavigationEnd) => {
+        const pageName = event.urlAfterRedirects.split('/').pop() || 'Home';
+        this.trackPage(pageName, {
+          path: event.urlAfterRedirects,
+          url: window.location.href,
+          title: document.title,
+        });
+      });
+  }
+}

--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -7,4 +7,8 @@ export const environment = {
     home: 'https://app.dev.lfx.dev',
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
   },
+  segment: {
+    cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
+    enabled: true,
+  },
 };

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -7,4 +7,8 @@ export const environment = {
     home: 'https://app.lfx.dev',
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
   },
+  segment: {
+    cdnUrl: 'https://lfx-segment.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
+    enabled: true,
+  },
 };

--- a/apps/lfx-one/src/environments/environment.staging.ts
+++ b/apps/lfx-one/src/environments/environment.staging.ts
@@ -7,4 +7,8 @@ export const environment = {
     home: 'https://app.staging.lfx.dev',
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
   },
+  segment: {
+    cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
+    enabled: true,
+  },
 };

--- a/apps/lfx-one/src/environments/environment.ts
+++ b/apps/lfx-one/src/environments/environment.ts
@@ -7,4 +7,8 @@ export const environment = {
     home: 'http://localhost:4200',
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
   },
+  segment: {
+    cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
+    enabled: true,
+  },
 };

--- a/packages/shared/src/interfaces/analytics.interface.ts
+++ b/packages/shared/src/interfaces/analytics.interface.ts
@@ -1,0 +1,66 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Segment configuration from environment
+ */
+export interface SegmentConfig {
+  /** Segment CDN URL for loading the analytics script */
+  cdnUrl: string;
+  /** Whether analytics is enabled for this environment */
+  enabled: boolean;
+}
+
+/**
+ * User traits for Segment identify calls
+ */
+export interface AnalyticsIdentifyTraits {
+  /** User's email address */
+  email?: string;
+  /** User's full name */
+  name?: string;
+  /** User's first name */
+  firstName?: string;
+  /** User's last name */
+  lastName?: string;
+  /** User's username */
+  username?: string;
+}
+
+/**
+ * Page properties for Segment page calls
+ */
+export interface AnalyticsPageProperties {
+  /** Page title */
+  title?: string;
+  /** Page URL or path */
+  path?: string;
+  /** Additional custom properties */
+  [key: string]: unknown;
+}
+
+/**
+ * LFX Segment Analytics API interface
+ * @description Type definitions for LfxSegmentsAnalytics object
+ */
+export interface LfxSegmentAnalytics {
+  /** Initialize the analytics instance */
+  init(): Promise<void>;
+  /** Track a page view */
+  page(pageName: string, properties?: Record<string, unknown>): void;
+  /** Track a custom event */
+  track(eventName: string, properties?: Record<string, unknown>): void;
+  /** Identify an Auth0 user */
+  identifyAuth0User(auth0User: unknown): void;
+  /** Reset analytics state */
+  reset(): void;
+}
+
+/**
+ * LFX Segment Analytics class interface
+ * @description Type definitions for LfxSegmentsAnalytics class
+ */
+export interface LfxSegmentAnalyticsClass {
+  /** Get the singleton instance */
+  getInstance(): LfxSegmentAnalytics;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -54,3 +54,6 @@ export * from './user-profile.interface';
 
 // User statistics interfaces
 export * from './user-statistics.interface';
+
+// Analytics interfaces
+export * from './analytics.interface';


### PR DESCRIPTION
## Summary
Integrates LF Segment analytics into LFXOne for user tracking and page analytics.

**JIRA**: [SWS-26](https://linuxfoundation.atlassian.net/browse/SWS-26)

## Changes
- ✅ Add `AnalyticsService` with SSR-safe script loading using `afterNextRender`
- ✅ Implement `trackPage()`, `trackEvent()`, and `identifyUser()` methods
- ✅ Add queueing system for identify calls before analytics is ready
- ✅ Configure environment-specific Segment CDN URLs (dev vs prod)
- ✅ Set up automatic page tracking on route navigation
- ✅ Add TypeScript interfaces for LF Segment API (`LfxSegmentAnalytics`)
- ✅ Integrate user identification on login with Auth0 user data

## Technical Details
- Uses `window.LfxAnalytics.LfxSegmentsAnalytics.getInstance()` API
- Methods: `trackPage(pageName, properties)`, `trackEvent(eventName, properties)`, `identifyAuth0User(auth0User)`
- SSR-safe with Angular 19's `afterNextRender` lifecycle hook
- Automatic route change tracking with page name extraction

## Test Plan
- [ ] Verify Segment script loads in browser console
- [ ] Confirm user identification on login
- [ ] Validate page tracking on route navigation
- [ ] Test in dev and prod environments with respective CDN URLs

[SWS-26]: https://linuxfoundation.atlassian.net/browse/SWS-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ