### PR TITLE
feat(meetings): enable resend invite for committee members with read-…

### DIFF
--- a/apps/lfx-one/src/app/modules/project/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/meeting-card/meeting-card.component.ts
@@ -207,26 +207,17 @@ export class MeetingCardComponent implements OnInit {
   public onRegistrantEdit(registrant: MeetingRegistrant, event: Event): void {
     event.stopPropagation();
 
-    // Don't allow editing committee members - show informational message
-    if (registrant.type === 'committee') {
-      this.messageService.add({
-        severity: 'info',
-        summary: 'Committee Member',
-        detail: 'This is a committee member. To update their details, please edit them in the individual committee(s)',
-      });
-      return;
-    }
-
     this.dialogService
       .open(RegistrantModalComponent, {
-        header: 'Edit Guest',
+        header: registrant.type === 'committee' ? 'Committee Member' : 'Edit Guest',
         width: '650px',
         modal: true,
         closable: true,
         dismissableMask: true,
         data: {
           meetingId: this.meeting().uid,
-          registrant: registrant, // Edit mode
+          registrant: registrant,
+          isCommitteeMember: registrant.type === 'committee',
         },
       })
       .onClose.pipe(take(1))

--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-modal/registrant-modal.component.html
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-modal/registrant-modal.component.html
@@ -5,6 +5,14 @@
   <!-- Use the existing registrant form component -->
   <lfx-registrant-form [form]="form" [registrant]="registrant" data-testid="registrant-modal-form-component"> </lfx-registrant-form>
 
+  <!-- Informational Message for Committee Members -->
+  @if (isCommitteeMember) {
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-blue-700" data-testid="registrant-modal-committee-info">
+      <i class="fa-light fa-info-circle mr-2"></i>
+      This is a committee member. To update their details or remove them, please edit the individual committee(s).
+    </div>
+  }
+
   <!-- Action Buttons -->
   <div class="flex border-t border-gray-200 pt-4 justify-between items-center" data-testid="registrant-modal-actions">
     @if (isEditMode) {
@@ -14,6 +22,9 @@
           severity="danger"
           size="small"
           type="button"
+          [disabled]="isCommitteeMember"
+          [tooltip]="isCommitteeMember ? 'Committee members must be removed via the committee' : ''"
+          tooltipPosition="top"
           (onClick)="onDeleteRegistrant()"
           data-testid="registrant-modal-delete-button">
         </lfx-button>
@@ -53,7 +64,9 @@
       <lfx-button
         [label]="isEditMode ? 'Update Registrant' : 'Add Registrant'"
         [loading]="submitting()"
-        [disabled]="form.invalid || submitting()"
+        [disabled]="form.invalid || submitting() || isCommitteeMember"
+        [tooltip]="isCommitteeMember ? 'Committee member details must be updated via the committee' : ''"
+        tooltipPosition="top"
         type="submit"
         size="small"
         data-testid="registrant-modal-submit-button">

--- a/apps/lfx-one/src/app/modules/project/meetings/components/registrant-modal/registrant-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/project/meetings/components/registrant-modal/registrant-modal.component.ts
@@ -31,6 +31,7 @@ export class RegistrantModalComponent {
   // Inputs
   public readonly meetingId = this.config.data.meetingId;
   public readonly registrant = this.config.data.registrant;
+  public readonly isCommitteeMember = this.config.data.isCommitteeMember || false;
 
   // Outputs
   public readonly registrantSaved = output<MeetingRegistrant>();
@@ -57,6 +58,15 @@ export class RegistrantModalComponent {
         org_name: this.registrant.org_name || '',
         host: this.registrant.host || false,
       });
+
+      // For committee members, disable all form controls except host
+      if (this.isCommitteeMember) {
+        Object.keys(this.form.controls).forEach((key) => {
+          if (key !== 'add_more_registrants') {
+            this.form.get(key)?.disable();
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
…only modal

When clicking on a committee member guest, now opens a modal with:
- Read-only form fields (all inputs disabled)
- Informational message about editing via committee
- Disabled delete/update buttons with helpful tooltips
- Fully functional resend invitation button

This allows organizers to resend meeting invitations to committee members while preventing direct edits that should be done via the committee management interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Here is a screenshot of the modal:

<img width="704" height="488" alt="Screenshot 2025-10-06 at 9 19 28 AM" src="https://github.com/user-attachments/assets/b946f95b-bf27-46fd-8bdc-23510f170168" />
