### PR TITLE
feat(permissions): fix user metadata lookup flow for email-based user…

### DIFF
--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -261,37 +261,14 @@ export class ProjectController {
 
       // Detect if input is email or username
       const isEmail = userData.username.includes('@');
-      let username = userData.username;
-
-      if (isEmail) {
-        req.log.info(
-          {
-            email: userData.username,
-            operation: 'add_user_project_permissions',
-          },
-          'Email detected, resolving to username via NATS'
-        );
-
-        // Resolve email to username via NATS
-        username = await this.projectService.resolveEmailToUsername(req, userData.username);
-
-        req.log.info(
-          {
-            email: userData.username,
-            username,
-            operation: 'add_user_project_permissions',
-          },
-          'Successfully resolved email to username'
-        );
-      }
-
+      
       // Check if manual user data is provided (for users not found in directory)
       let manualUserInfo: { name: string; email: string; username: string; avatar?: string } | undefined;
       if (userData.name || userData.email || userData.avatar) {
         manualUserInfo = {
           name: userData.name || '',
           email: userData.email || '',
-          username,
+          username: userData.username, // Keep the original input for manual user info
         };
         // Only include avatar if it's not empty
         if (userData.avatar) {
@@ -299,13 +276,15 @@ export class ProjectController {
         }
       }
 
-      const result = await this.projectService.updateProjectPermissions(req, uid, 'add', username, userData.role, manualUserInfo);
+      // Pass the original input (email or username) to updateProjectPermissions
+      // The service will handle the email_to_sub -> email_to_username flow internally
+      const result = await this.projectService.updateProjectPermissions(req, uid, 'add', userData.username, userData.role, manualUserInfo);
 
       Logger.success(req, 'add_user_project_permissions', startTime, {
         uid,
-        username,
+        username: userData.username,
         role: userData.role,
-        resolved_from_email: isEmail,
+        is_email: isEmail,
       });
 
       res.status(201).json(result);

--- a/packages/shared/src/enums/nats.enum.ts
+++ b/packages/shared/src/enums/nats.enum.ts
@@ -7,6 +7,7 @@
 export enum NatsSubjects {
   PROJECT_SLUG_TO_UID = 'lfx.projects-api.slug_to_uid',
   USER_METADATA_UPDATE = 'lfx.auth-service.user_metadata.update',
+  USER_METADATA_READ = 'lfx.auth-service.user_metadata.read',
   EMAIL_TO_USERNAME = 'lfx.auth-service.email_to_username',
   EMAIL_TO_SUB = 'lfx.auth-service.email_to_sub',
   USERNAME_TO_USER_INFO = 'lfx.auth-service.username_to_user_info',


### PR DESCRIPTION
… management

Update project permission system to use correct NATS endpoints for user information retrieval:
- Add USER_METADATA_READ NATS subject for lfx.auth-service.user_metadata.read
- Fix getUserInfo to use email_to_username result for user metadata lookup
- Maintain email_to_sub for backend storage consistency (auditors/writers)
- Handle proper response format from user metadata service
- Map picture field to avatar and construct names from metadata

🤖 Generated with [Claude Code](https://claude.ai/code)